### PR TITLE
Rev bounds2d

### DIFF
--- a/miter-vert.glsl
+++ b/miter-vert.glsl
@@ -35,8 +35,6 @@ bool isNaN( float val ){
 void main() {
 	vec2 aCoord = aCoord, bCoord = bCoord, prevCoord = prevCoord, nextCoord = nextCoord;
 
-	// adjust scale for horizontal bars
-	vec2 scale = max(scale, MIN_DIFF);
 	vec2 scaleRatio = scale * viewport.zw;
 
 	vec2 normalWidth = thickness / scaleRatio;

--- a/miter-vert.glsl
+++ b/miter-vert.glsl
@@ -35,9 +35,9 @@ bool isNaN( float val ){
 void main() {
 	vec2 aCoord = aCoord, bCoord = bCoord, prevCoord = prevCoord, nextCoord = nextCoord;
 
-  vec2 adjustedScale = scale;
-  if (abs(scale.x) < MIN_DIFF) adjustedScale.x = MIN_DIFF; // * sign(scale.x);
-  if (abs(scale.y) < MIN_DIFF) adjustedScale.y = MIN_DIFF; // * sign(scale.y);
+  vec2 adjustedScale;
+  adjustedScale.x = (abs(scale.x) < MIN_DIFF) ? MIN_DIFF : scale.x;
+  adjustedScale.y = (abs(scale.y) < MIN_DIFF) ? MIN_DIFF : scale.y;
 
   vec2 scaleRatio = adjustedScale * viewport.zw;
 	vec2 normalWidth = thickness / scaleRatio;

--- a/miter-vert.glsl
+++ b/miter-vert.glsl
@@ -35,8 +35,11 @@ bool isNaN( float val ){
 void main() {
 	vec2 aCoord = aCoord, bCoord = bCoord, prevCoord = prevCoord, nextCoord = nextCoord;
 
-	vec2 scaleRatio = scale * viewport.zw;
+  vec2 adjustedScale = scale;
+  if (abs(scale.x) < MIN_DIFF) adjustedScale.x = MIN_DIFF; // * sign(scale.x);
+  if (abs(scale.y) < MIN_DIFF) adjustedScale.y = MIN_DIFF; // * sign(scale.y);
 
+  vec2 scaleRatio = adjustedScale * viewport.zw;
 	vec2 normalWidth = thickness / scaleRatio;
 
 	float lineStart = 1. - lineEnd;
@@ -139,11 +142,11 @@ void main() {
 		aBotCoord += normalize(startBotJoin * normalWidth) * abClipping;
 	}
 
-	vec2 aTopPosition = (aTopCoord) * scale + translate;
-	vec2 aBotPosition = (aBotCoord) * scale + translate;
+	vec2 aTopPosition = (aTopCoord) * adjustedScale + translate;
+	vec2 aBotPosition = (aBotCoord) * adjustedScale + translate;
 
-	vec2 bTopPosition = (bTopCoord) * scale + translate;
-	vec2 bBotPosition = (bBotCoord) * scale + translate;
+	vec2 bTopPosition = (bTopCoord) * adjustedScale + translate;
+	vec2 bBotPosition = (bBotCoord) * adjustedScale + translate;
 
 	//position is normalized 0..1 coord on the screen
 	vec2 position = (aTopPosition * lineTop + aBotPosition * lineBot) * lineStart + (bTopPosition * lineTop + bBotPosition * lineBot) * lineEnd;


### PR DESCRIPTION
This PR could enable the use of simple lines (with no markers/texts) in 2D scenes that declared with `autorange:'reversed'` or `ranges:[greater value, smaller value]`
Please refer to this plotly [issue](https://github.com/plotly/plotly.js/issues/2904) and plotly [PR](https://github.com/plotly/plotly.js/pull/3078).
@dy @alexcjohnson  
